### PR TITLE
カテゴリー詳細ページの作成

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,3 +11,4 @@
 // @import "./update";
 // @import "./destroy";
 @import "./modules/categories/index";
+@import "./modules/categories/show";

--- a/app/assets/stylesheets/modules/_header.scss
+++ b/app/assets/stylesheets/modules/_header.scss
@@ -23,7 +23,7 @@
             border: 0;
             cursor: pointer;
             &:hover {
-              opacity: 0.9;
+              opacity: 0.8;
             }
             .search-icon {
               @include heightWidth(20px, 20px);
@@ -44,8 +44,11 @@
           cursor: pointer;
           &__category {
             margin-right: 30px;
-            &:hover {
-              color: $leftListHover;
+            .category-link {
+              @include linkReset();
+              &:hover {
+                color: $leftListHover;
+              }
             }
           }
           &__bland {
@@ -62,14 +65,14 @@
             @include headerBottomRight($mainColor, $mainColor);
             margin-right: 20px;
             &:hover {
-              opacity: 0.9;
+              opacity: 0.8;
             }
           }
           &__member {
             @include headerBottomFont($mainFont);
             @include headerBottomRight($mainColor, $headerBg);
             &:hover {
-              opacity: 0.9;
+              opacity: 0.8;
             }
           }
         }

--- a/app/assets/stylesheets/modules/categories/_show.scss
+++ b/app/assets/stylesheets/modules/categories/_show.scss
@@ -1,3 +1,26 @@
+.category-nav {
+  background-color: #fff;
+  padding: 0 5%;
+  border-top: 1px solid #eee;
+  filter: drop-shadow(0 3px 1px #aaa);
+  &__list {
+    display: flex;
+    padding: 15px 0 ;
+    .nav-list {
+      padding-right: 10px;
+      .nav-link {
+        @include linkReset();
+        &:hover {
+          color: $mainColor;
+        }
+      }
+    }
+    .last-list {
+      font-weight: bold;
+    }
+  }
+}
+
 .category-show {
   width: 700px;
   margin: 30px auto;

--- a/app/assets/stylesheets/modules/categories/_show.scss
+++ b/app/assets/stylesheets/modules/categories/_show.scss
@@ -1,0 +1,74 @@
+.category-show {
+  width: 700px;
+  margin: 30px auto;
+  &__top {
+    @include fontSizeColorBold(20px, $whiteFont);
+    height: 50px;
+    line-height: 50px;
+    background-color: $mainColor;
+    padding-left: 20px;
+  }
+  &__sub {
+    background-color: #fff;
+    padding: 10px;
+    .sub-category {
+      margin: 10px;
+      float: left;
+      .sub-list {
+        @include linkReset($linkFont);
+        &:hover {
+          @include categoryLinkHover;
+        }
+      }
+    }
+  }
+  &__items {
+    display: flex;
+    flex-wrap: wrap;
+    width: 705px;
+    margin: 30px 0;
+    .item-list {
+      width: 230px;
+      margin: 0 5px 5px 0;
+      filter: drop-shadow(3px 3px 1px #aaa);
+      &:hover {
+        opacity: 0.8;
+      }
+      .item-link {
+        @include linkReset;
+      }
+      &__image {
+        width: auto;
+        height: 150px;
+        background-color: #aaa;
+        position: relative;
+        overflow: hidden;
+        .item-image {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+        }
+        .item-price {
+          background-color: rgba(0,0,0,0.4);
+          position: absolute;
+          left: 0;
+          bottom: 5px;
+          border-radius: 0 14px 14px 0;
+          &__display {
+            color: #fff;
+            padding: 0 8px;
+          }
+        }
+      }
+      &__body {
+        background-color: #fff;
+        padding: 10px;
+        &--name {
+          height: 46px;
+          overflow: hidden;
+        }
+      }
+    }
+  }
+}

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  # itemが使用可能になり次第、適用
   # before_action :set_item
 
   def index
@@ -9,6 +10,7 @@ class CategoriesController < ApplicationController
     @category = Category.find(params[:id])
   end
 
+  # itemが使用可能になり次第、適用
   # def set_item
   #   @item = Item.find(params[:item_id])
   # end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,6 @@
 class CategoriesController < ApplicationController
+  # before_action :set_item
+
   def index
     @categories = Category.all.order("id ASC")
   end
@@ -6,4 +8,8 @@ class CategoriesController < ApplicationController
   def show
     @category = Category.find(params[:id])
   end
+
+  # def set_item
+  #   @item = Item.find(params[:item_id])
+  # end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -1,2 +1,20 @@
 module CategoriesHelper
+  def navList(category)
+    nav = [
+      {name: "FURIMA", path: "/"},
+      {name: "カテゴリー一覧", path: "/categories"}
+    ]
+
+    if category.parent
+      parent = category.parent
+      parent_data = {name: parent.name, path: "/categories/#{parent.id}"}
+      if parent.parent
+        grand_parent = parent.parent
+        grand_parent_data = {name: grand_parent.name, path: "/categories/#{grand_parent.id}"}
+        nav << grand_parent_data
+      end
+      nav << parent_data
+    end
+    nav << {name: category.name, path: "/categories/#{category.id}"}
+  end
 end

--- a/app/views/categories/_category.html.haml
+++ b/app/views/categories/_category.html.haml
@@ -4,7 +4,7 @@
       = category.name
     %ul.category-children
       .category-children__all
-        = link_to "#", class: "perent-all" do
+        = link_to category_path(category[:id]), class: "perent-all" do
           = "#{category.name}一覧"
       - category.children.each do |child|
         %li.category-children__box
@@ -12,9 +12,9 @@
             = child.name
           %ul.category-grandChild.clearfix
             .category-grandChild__all
-              = link_to "#", class: "children-all" do
+              = link_to category_path(child[:id]), class: "children-all" do
                 = "#{child.name}一覧"
             - child.children.each do |grandChild|
               %li.category-grandChild__box
-                = link_to "#", class: "grandChild-list" do
+                = link_to category_path(grandChild[:id]), class: "grandChild-list" do
                   = grandChild.name

--- a/app/views/categories/_nav.html.haml
+++ b/app/views/categories/_nav.html.haml
@@ -1,0 +1,14 @@
+.category-nav
+  %ul.category-nav__list
+    - list = navList(@category)
+    - list.each_with_index do |data, index|
+      - if index < list.size - 1
+        %li.nav-list
+          = link_to data[:path], class: "nav-link" do
+            = data[:name]
+          %li.nav-list
+            >
+      - else
+        %li.nav-list.last-list
+          = link_to data[:path], class: "nav-link" do
+            = data[:name]

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,5 +1,6 @@
 .wrapper
   = render "shared/header"
+  = render "nav"
   .category-show
     .category-show__top
       = "#{@category.name}の一覧"

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,0 +1,76 @@
+.wrapper
+  = render "shared/header"
+  .category-show
+    .category-show__top
+      = "#{@category.name}の一覧"
+    - if @category.children.present?
+      %ul.category-show__sub.clearfix
+        - @category.children.each do |category|
+          %li.sub-category
+            = link_to category_path(category[:id]), class: "sub-list" do
+              = category.name
+    .category-show__items.clearfix
+      -# - @items.each do |item|
+      -#   .item-list
+      -#     = link_to item_path(params[:item_id]), class: "item-link" do
+      -#       .item-list__image
+      -#         = image_tag item.images[0].image, alt: "#{item.name}", class: "item-image"
+      -#         .item-price
+      -#           .item-price__display
+      -#             = "#{item.price}円"
+      -#       .item-list__body
+      -#         .item-list__body--name
+      -#           = item.name
+      -# itemテーブルから呼び出せるようになり次第、
+      -# 上記記述を適用し、以下をfooter手前まで削除
+      .item-list
+        = link_to "#", class: "item-link" do
+          .item-list__image
+            = image_tag "", alt: "商品一覧", class: "item-image"
+            .item-price
+              .item-price__display
+                490円
+          .item-list__body
+            .item-list__body--name
+              ドライカレーだあああああああああああああああああああああ
+      .item-list
+        = link_to "#", class: "item-link" do
+          .item-list__image
+            = image_tag "", alt: "商品一覧", class: "item-image"
+            .item-price
+              .item-price__display
+                490円
+          .item-list__body
+            .item-list__body--name
+              ドライカレーだあああああああああああああああああああああ
+      .item-list
+        = link_to "#", class: "item-link" do
+          .item-list__image
+            = image_tag "", alt: "商品一覧", class: "item-image"
+            .item-price
+              .item-price__display
+                490円
+          .item-list__body
+            .item-list__body--name
+              ドライカレーだあああああああああああああああああああああ
+      .item-list
+        = link_to "#", class: "item-link" do
+          .item-list__image
+            = image_tag "", alt: "商品一覧", class: "item-image"
+            .item-price
+              .item-price__display
+                490円
+          .item-list__body
+            .item-list__body--name
+              ドライカレーだあああああああああああああああああああああ
+      .item-list
+        = link_to "#", class: "item-link" do
+          .item-list__image
+            = image_tag "", alt: "商品一覧", class: "item-image"
+            .item-price
+              .item-price__display
+                490円
+          .item-list__body
+            .item-list__body--name
+              ドライカレーだあああああああああああああああああああああ
+  = render "shared/footer"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -13,7 +13,8 @@
       .contents-bottom__left
         .left-list
           .left-list__category
-            カテゴリー
+            = link_to categories_path, class: "category-link" do
+              カテゴリー
           .left-list__bland
             ブランド
       .contents-bottom__right

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,6 @@ ActiveRecord::Schema.define(version: 2020_02_17_084208) do
     t.string "destination_last_name", null: false
     t.string "destination_family_name_kana", null: false
     t.string "destination_last_name_kana", null: false
-    t.integer "postal_code", null: false
     t.string "prefectures", null: false
     t.string "municipalities", null: false
     t.string "address", null: false


### PR DESCRIPTION
## What
カテゴリーの詳細ページを作成するため、show.html.hamlと_show.scssを作成した。
また、カテゴリーページへ遷移するため_header.html.hamlとcategories/index.html.hamlにリンクを記述した。

## Why
ユーザー側にとってカテゴリーからの商品検索は利便性の向上に繋がるため。

## other
itemsが使用できるようになり次第、showページでのitem一覧を解放する。